### PR TITLE
Add to_bytes func for SecretKey

### DIFF
--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -751,6 +751,14 @@ impl SecretKey {
     pub fn to_bytes(&self) -> [u8; 32] {
         self.key.to_bytes()
     }
+
+    /// Create new SecretKey from raw data like index and Scalar in bytes
+    pub fn new_from_index_and_secret(index: u32, key: [u8; 32]) -> Self {
+        Self {
+            index,
+            key: Scalar::from_bits(key),
+        }
+    }
 }
 
 impl From<&SecretKey> for IndividualPublicKey {

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -746,6 +746,11 @@ impl SecretKey {
             share,
         }
     }
+
+    /// Returns raw secret key
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.key.to_bytes()
+    }
 }
 
 impl From<&SecretKey> for IndividualPublicKey {


### PR DESCRIPTION
# What

This PR introduces two new methods for the `SecretKey` struct: to_bytes and new_from_index_and_secret.

# Why

These methods improve the library's usability in real-world scenarios.

- `to_bytes()` After generating a secret key for a participant, the next step is often to store it in a raw format. The `to_bytes()` method facilitates this by converting the key into a storable byte array.

- `new_from_index_and_secret()` In the reverse scenario, when a stored key needs to be used for signing a message, this method allows us to reconstruct the `SecretKey` struct by reading the key and providing the required index and secret.

These additions streamline the process of managing secret keys, making the library more practical for real-world applications.

# Further possible improvements

The flow with code snippets is already well-documented at [docs.rs/frost-dalek](https://docs.rs/frost-dalek). In this README, I aim to provide a high-level overview of the processes using diagrams for better conceptual understanding.

For instance:

- Key Generation. There are two rounds involved in the key generation process. Including a detailed description of these rounds accompanied by diagrams would make the explanation much clearer.
- Message Signing. Similarly, illustrating the message signing process with at least one diagram would greatly help developers.

This way, we can provide two complementary resources for users to learn about FROST:

- High-Level Overview. This README will help users understand the protocol and its workflows conceptually.
- Practical Usage. The crate documentation will guide users through practical implementation with detailed code snippets.

Additionally, incorporating example code snippets directly into this repository would be an excellent enhancement. These examples could simulate different scenarios, enabling users to better understand and experiment with the library in practice.

It’s also not entirely clear why we call `include_signer()` for the signature aggregator and pass `comshares.commitments[0]`. Adding a dedicated function to return the necessary commitment would improve clarity, as it’s currently unclear to new developers why the zero index commitment is being used.